### PR TITLE
Update README.md to include SkyFlipTracker as a needed dependecy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,5 @@ git clone --depth=1 https://github.com/Coflnet/SkySettings
 git clone --depth=1 https://github.com/Coflnet/SkyPlayerName
 git clone --depth=1 https://github.com/Coflnet/SkyFilter
 git clone --depth=1 https://github.com/Coflnet/SkyCrafts
+git clone --depth=1 https://github.com/Coflnet/SkyFlipTracker
 ```


### PR DESCRIPTION
Hey, i'm not sure if i've read this wrong - but I tried to follow the instructions set out in your usage guide but it fails without this being cloned.

unable to prepare context: path "D:\\skyblock\\SkyFlipTracker" not found